### PR TITLE
Allow zero users to keep.

### DIFF
--- a/includes/pruners/users.php
+++ b/includes/pruners/users.php
@@ -42,7 +42,6 @@ function pruner( $limit, $sort_type = false ) {
 					$keep_ids[] = $keep_id;
 					$remaining--;
 				}
-
 			}
 		}
 
@@ -59,9 +58,7 @@ function pruner( $limit, $sort_type = false ) {
 				wp_delete_user( $user_to_delete->ID, $new_author_id );
 			}
 		}
-
 	}
-
 }
 
 add_action( 'wp_hammer_run_prune_users', __NAMESPACE__ . '\pruner' );

--- a/includes/pruners/users.php
+++ b/includes/pruners/users.php
@@ -51,8 +51,9 @@ function pruner( $limit, $sort_type = false ) {
 		if ( $users_to_delete->total_users ) {
 			require_once( ABSPATH . 'wp-admin/includes/user.php' );
 
+			// Determine the author ID to use for post reassignment.
+			$new_author_id = ! empty( $keep_ids ) ? min( $keep_ids ) : null;
 			foreach( $users_to_delete->results as $user_to_delete ) {
-				$new_author_id = min( $keep_ids );
 				\WP_CLI::line( "Deleting user {$user_to_delete->ID} and reassigning their posts to user ID: $new_author_id" );
 				// Delete user and reassign their posts to the smallest user ID that will remain.
 				wp_delete_user( $user_to_delete->ID, $new_author_id );


### PR DESCRIPTION
This change does double-duty:
* It ensures that the `$new_author_id` variable is only set once
* It allows for an empty set of `$keep_ids`, which Fixes #5

In addition, a few unneeded blank lines were removed.