### PR TITLE
Bumps require version of roderik/pwgen-php to 1.0.7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/10up/wp-hammer",
     "require": {
         "joshtronic/php-loremipsum": "dev-master",
-        "roderik/pwgen-php": "dev-master",
+        "roderik/pwgen-php": "0.1.7",
         "heidilabs/markov-php": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Fixes pwgen-php not installable by composer.

```
Installing package ivankruchkoff/wp-hammer (dev-master)
Updating /srv/http/.wp-cli/packages/composer.json to require the package...
Using Composer to install the package...
---
Loading composer repositories with package information
Updating dependencies
Resolving dependencies through SAT
Dependency resolution completed in 0.154 seconds
Your requirements could not be resolved to an installable set of packages.
Problem 1
    - Installation request for ivankruchkoff/wp-hammer dev-master -> satisfiable by ivankruchkoff/wp-hammer[dev-master].
    - ivankruchkoff/wp-hammer dev-master requires roderik/pwgen-php dev-master -> no matching package found.
Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see https://getcomposer.org/doc/04-schema.md#minimum-stability for more details.
 - It's a private package and you forgot to add a custom repository to find it
Read https://getcomposer.org/doc/articles/troubleshooting.md for further common problems.
Running update with --no-dev does not mean require-dev is ignored, it just means the packages will not be installed. If dev requirements are blocking the update you have to resolve those problems.
---
Error: Package installation failed (Composer return code 2).
Reverted composer.json.
```