### PR TITLE
Fix: Can not replace posts with dummy posts

### DIFF
--- a/includes/generators/generic.php
+++ b/includes/generators/generic.php
@@ -3,7 +3,7 @@
 namespace WP_CLI\Hammer\Generators\Generic;
 use WP_CLI\Iterators\Query;
 use joshtronic\LoremIpsum;
-use PWGen;
+use PWGen\PWGen;
 use MarkovPHP\WordChain;
 
 /**


### PR DESCRIPTION
### Description of the Change
This PR use namespaced `PWGen` due to the recent changes of `roderik/pwgen-php`.
See: https://github.com/roderik/pwgen-php/commit/299a78faf28a4bfdf8003e8d0fdeb9009a27ed50#diff-28d119bc02492589c6375f38d346a403

### Benefits
The plugin works with new installations now.

### Verification Process
1. Run `wp ha -f posts.post_content=markov,posts.post_title=random`
2. See the command runs successfully and the post title and content are replaced.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues
Close #17 