### PR TITLE
Fix: Using deprecated function

### DIFF
--- a/includes/formatters/users.php
+++ b/includes/formatters/users.php
@@ -65,7 +65,7 @@ function user_pass( $user, $formatter ) {
 		debug_print_backtrace();
 	}
 	if ( 'auto' === $formatter ) {
-		$new_password = bin2hex( mcrypt_create_iv( 12, MCRYPT_DEV_URANDOM ) );
+		$new_password = generate_random_password();
 		\WP_CLI::line( "New password for user {$user[ 'ID' ]} is {$new_password}" );
 		$user[ 'user_pass' ] = wp_hash_password( $new_password );
 	} else {
@@ -73,6 +73,25 @@ function user_pass( $user, $formatter ) {
 		$user[ 'user_pass' ] = wp_hash_password( $formatter );
 	}
 	return $user;
+}
+
+/**
+ * Generate a random password. Support both PHP 5.6 and PHP 7.0+.
+ *
+ * @return string
+ */
+function generate_random_password() {
+	$password = 'password';
+
+	if ( function_exists( 'random_bytes' ) ) {
+		$password = bin2hex( random_bytes( 12 ) );
+	}
+
+	if ( function_exists( 'mcrypt_create_iv' ) ) {
+		$password = bin2hex( mcrypt_create_iv( 12, MCRYPT_DEV_URANDOM ) );
+	}
+
+	return $password;
 }
 
 add_filter( 'wp_hammer_run_formatter_filter_users_user_email', __NAMESPACE__ . '\user_email', null , 2 );

--- a/includes/formatters/users.php
+++ b/includes/formatters/users.php
@@ -81,17 +81,11 @@ function user_pass( $user, $formatter ) {
  * @return string
  */
 function generate_random_password() {
-	$password = 'password';
-
 	if ( function_exists( 'random_bytes' ) ) {
-		$password = bin2hex( random_bytes( 12 ) );
+		return bin2hex( random_bytes( 12 ) );
 	}
 
-	if ( function_exists( 'mcrypt_create_iv' ) ) {
-		$password = bin2hex( mcrypt_create_iv( 12, MCRYPT_DEV_URANDOM ) );
-	}
-
-	return $password;
+	return bin2hex( mcrypt_create_iv( 12, MCRYPT_DEV_URANDOM ) );
 }
 
 add_filter( 'wp_hammer_run_formatter_filter_users_user_email', __NAMESPACE__ . '\user_email', null , 2 );


### PR DESCRIPTION
### Description of the Change
This PR adds generate random password support for multiple PHP versions.

### Benefits

The random password generator now works with both PHP 5.6 and 7.0+.

### Verification Process

1. Run `wp ha -f users.user_pass=auto`.
2. See passwords generated successfully.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #16 
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
