### PR TITLE
Allow pruning by post type

### DIFF
--- a/includes/Prune.php
+++ b/includes/Prune.php
@@ -25,17 +25,25 @@ class Prune {
 			if ( 2 === count( $options ) ) {
 				$table = $options[0];
 				$element_prune = explode( '.', $options[1] );
-				$number_of_rows = $element_prune[0];
-				$sort_type = isset( $element_prune[1] ) ? $element_prune[1] : null;
-				$this->add_prune( $table, $number_of_rows, $sort_type );
+				if (count($element_prune) <= 2) {
+					$number_of_rows = $element_prune[0];
+					$sort_type = isset( $element_prune[1] ) ? $element_prune[1] : null;
+					$this->add_prune( $table, $number_of_rows, $sort_type );
+				} elseif ( $table == 'posts' && count( $element_prune ) > 2 ) {
+					$post_type = $element_prune[0];
+					$number_of_rows = $element_prune[1];
+					$sort_type = isset( $element_prune[2] ) ? $element_prune[2] : null;
+					$this->add_prune( $table, $number_of_rows, $sort_type, $post_type );
+				}
 			}
 		}
 	}
 
-	function add_prune( $table, $number_of_rows, $sort_type ) {
+	function add_prune( $table, $number_of_rows, $sort_type, $post_type = null ) {
 		$this->prunes[ $table ] = array(
 			'prune' => $number_of_rows,
 			'sort_type' => $sort_type,
+			'post_type' => $post_type
 		);
 	}
 
@@ -53,7 +61,7 @@ class Prune {
 				/**
 				 * Any code that needs to be run prior to pruning a table.
 				 */
-				do_action( 'wp_hammer_run_prune_' . $table, $prune[ 'prune' ], $prune[ 'sort_type' ] );
+				do_action( 'wp_hammer_run_prune_' . $table, $prune[ 'prune' ], $prune[ 'sort_type' ], $prune[ 'post_type' ] );
 			}
 
 		}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Adds the ability to prune posts by specific post type, as described in the README.

e.g. `wp ha -l posts=page.100.post_date` to keep only the 100 pages with most recent post dates.

If no post type is specified (e.g. `wp ha -l posts=100.post_date`) the command works as before.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (N/A)
- [ ] I have updated the documentation accordingly. (N/A)
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

I haven't updated the tests, as I'm not sure how to get them running (e.g. there's no requirement for PHPUnit in `composer.json`). If someone explains how to get them running, I'm happy to update them 🙂 

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Resolves #25 
