### PR TITLE
Avoid use of glob_brace

### DIFF
--- a/includes/Command.php
+++ b/includes/Command.php
@@ -52,7 +52,12 @@ class Command extends \WP_CLI_Command {
 		// All content manipulators are stored in pruners, formatters, sanitizers, generators folders. They are namespaced, but not in classes,
 		// so we can't use the autoloader for them.
 		// Also, because they need add_action/add_filter to load, we can only include them after WP has loaded, so it's not part of the autoloader.
-		$content_manipulators = glob( __DIR__ . '/{pruners,formatters,sanitizers,generators}/*.php', GLOB_BRACE );
+		$content_manipulators = array_merge(
+			glob( __DIR__ . '/pruners/*.php' ),
+			glob( __DIR__ . '/formatters/*.php' ),
+			glob( __DIR__ . '/sanitizers/*.php' ),
+			glob( __DIR__ . '/generators/*.php' )
+		);
 
 		foreach ( $content_manipulators as $content_manipulator ) {
 			require_once $content_manipulator;


### PR DESCRIPTION
### Avoid use of GLOB_BRACE as is not always available. 

When I try to run WP Hammer I get the following errors: 

```
PHP Warning:  Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' (this will throw an Error in a future version of PHP) in ...wp-hammer/includes/Command.php on line 55
PHP Warning:  glob() expects parameter 2 to be int, string given in ...wp-hammer/includes/Command.php on line 55
PHP Warning:  Invalid argument supplied for foreach() in ...wp-hammer/includes/Command.php on line 64
```

Looking at the [PHP docs for glob](https://www.php.net/manual/en/function.glob.php), I notice the following. 

> Note: The GLOB_BRACE flag is not available on some non GNU systems, like Solaris or Alpine Linux.

 My local environment is docker based on Docker, that I think is built on Alpine Linux, so explains why this is not available. 

### Alternate Designs

It seems an easy enough change to avoid the use of GLOB_BRACE to ensure wp-hammer works on more environments. 

### Possible Drawbacks

`GLOB_BRACE` is neater, and probably more efficient. But seems like a pretty small difference. 

### Verification Process

* Run hammer commands and verify they still run OK. 
* Test on an environment without GLOB_BRACE available and verify hammer commands are working. 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
